### PR TITLE
Update fragment_audio_genre.java

### DIFF
--- a/app/src/main/java/com/codeboy/mediafacer_examples/fragments/fragment_audio_genre.java
+++ b/app/src/main/java/com/codeboy/mediafacer_examples/fragments/fragment_audio_genre.java
@@ -50,7 +50,7 @@ public class fragment_audio_genre extends Fragment {
         progressBar = parentView.findViewById(R.id.progress);
         progressBar.setVisibility(View.GONE);
 
-        GenreNames.setHasFixedSize(true);
+        // GenreNames.setHasFixedSize(true);
         GenreNames.setItemViewCacheSize(20);
         GenreNames.setDrawingCacheEnabled(true);
         GenreNames.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);


### PR DESCRIPTION
setHasFixedSize() in an RecyclerView(@id/genre_names), wrap_content cannot be used as a value for size in the scrolling direction